### PR TITLE
chore: change init-db script

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -8,7 +8,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "init-db": "drizzle-kit generate --name init_db && drizzle-kit migrate",
+    "init-db": "drizzle-kit push",
     "db-studio": "drizzle-kit studio",
     "clear-db": "rm -rf migrations sqlite.db"
   },


### PR DESCRIPTION
优化 `init-db` 初始化数据库脚本，不用特地生成 migrations 文件夹，[参考](https://orm.drizzle.team/kit-docs/commands#prototype--push)